### PR TITLE
Fix rendering for multi-lingual link dialogs

### DIFF
--- a/app/views/alchemy/admin/pages/_page_for_links.html.erb
+++ b/app/views/alchemy/admin/pages/_page_for_links.html.erb
@@ -22,7 +22,7 @@
       <span class="page_status {{#unless visible}}not_{{/unless}}visible" title="{{status_titles.visible}}"></span>
       <span class="page_status {{#unless restricted}}not_{{/unless}}restricted" title="{{status_titles.restricted}}"></span>
     </div>
-    <div class="sitemap_sitename" id="sitemap_sitename_{{id}}" name="/<%= "#{Language.current.code}/" if multi_language? %> %>{{urlname}}">
+    <div class="sitemap_sitename" id="sitemap_sitename_{{id}}" name="/<%= "#{Alchemy::Language.current.code}/" if multi_language? %> %>{{urlname}}">
       {{#if redirects_to_external}}
         <span class="sitemap_pagename_link inactive">{{ name }}</span>
       {{else}}


### PR DESCRIPTION
The Language constant belongs to the Alchemy package. Trying to use it
here without the namespace prefix causes an uninitialized constant error
for ActionView::CompiledTemplates::Language
