### PR TITLE
Use Alchemy dialog list to look up Link dialogs

### DIFF
--- a/app/assets/javascripts/tinymce/plugins/alchemy_link/plugin.min.js
+++ b/app/assets/javascripts/tinymce/plugins/alchemy_link/plugin.min.js
@@ -5,15 +5,15 @@ tinymce.PluginManager.add('alchemy_link', function(editor, url) {
     shortcut: 'Ctrl+K',
     stateSelector: 'a[href]',
     onclick: function () {
-      var link_object = {
+      var linkObject = {
         node: editor.selection.getNode(),
         bookmark: editor.selection.getBookmark(),
         selection: editor.selection,
         editor: editor
       };
-      window.dialog = new Alchemy.LinkDialog(link_object);
+      var linkDialog = new Alchemy.LinkDialog(linkObject);
       editor.focus();
-      window.dialog.open();
+      linkDialog.open();
     }
   });
 });

--- a/app/views/alchemy/admin/pages/_sitemap.html.erb
+++ b/app/views/alchemy/admin/pages/_sitemap.html.erb
@@ -26,7 +26,7 @@
      <% end %>
      <% if @link %>
      ,function () {
-       window.dialog.attachEvents();
+       Alchemy.currentDialog().attachEvents();
      }
      <% end %>
    );

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -33,7 +33,7 @@
 ) %>
 
 <%= link_to(render_icon(:link), '', {
-  onclick: 'window.dialog = new Alchemy.LinkDialog(this); window.dialog.open(); return false;',
+  onclick: 'new Alchemy.LinkDialog(this).open(); return false;',
   class: content.linked? ? 'linked' : nil,
   title: _t(:link_image),
   'data-content-id' => content.id,

--- a/app/views/alchemy/essences/shared/_linkable_essence_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_linkable_essence_tools.html.erb
@@ -2,7 +2,7 @@
   <%= link_to(
     render_icon(:link),
     '#',
-    onclick: "window.dialog = new Alchemy.LinkDialog(this); window.dialog.open(); return false;",
+    onclick: 'new Alchemy.LinkDialog(this).open(); return false;',
     class: "icon_button#{content.linked? ? ' linked' : ''}",
     'data-content-id' => content.id,
     title: _t(:place_link),


### PR DESCRIPTION
This prevents the need to store the link dialog objects in the global
window object's namespace.

Also fixes up some variable naming to use camelCase rather than
snake_case
