### PR TITLE
Put spinner in the center of link dialogs

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee
@@ -25,13 +25,12 @@ Alchemy.Sitemap =
     request = $.ajax url: @url, data:
       id: @page_root_id
       full: @full
+    spinner = Alchemy.Spinner.small()
 
     if foldingId
-      spinner = Alchemy.Spinner.small()
       spinTarget = $('#fold_button_' + foldingId)
     else
-      spinner = Alchemy.Spinner.medium()
-      spinTarget = self.sitemap_wrapper
+      spinTarget = self.sitemap_wrapper.find('.sitemap-load-notice')
 
     spinner.spin(spinTarget[0])
 

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -149,6 +149,8 @@ div#overlay_text_box {
 }
 
 #archive_all {
+  @include box-sizing(border-box);
+  height: 100%;
   padding-bottom: 60px;
 
   &.with_tag_filter {

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -19,7 +19,21 @@
 }
 
 #sitemap-wrapper {
-  min-height: 400px;
+  position: relative;
+  min-height: 100%;
+
+  .sitemap-load-notice {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .spinner {
+    left: 0 !important;
+    top: -1px !important;
+    margin-right: 10px;
+  }
 }
 
 .sitemap_pagename_link {

--- a/app/views/alchemy/admin/pages/_sitemap.html.erb
+++ b/app/views/alchemy/admin/pages/_sitemap.html.erb
@@ -1,4 +1,5 @@
 <div id="sitemap-wrapper">
+  <p class="center sitemap-load-notice"><%= _t(:loading_sitemap) %></p>
 </div>
 
 <script id="sitemap-template" type="text/x-handlebars-template">

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -427,6 +427,7 @@ de:
       file: "Datei"
       internal: "Intern"
     link_title: "Linktitel"
+    loading_sitemap: "Seitenbaum wird geladen"
     login: "anmelden"
     logout: "abmelden"
     mail_to: "Empfängeradresse"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -427,6 +427,7 @@ en:
       file: "File"
       internal: "Internal"
     link_title: "Link title"
+    loading_sitemap: "Loading sitemap"
     login: "login"
     logout: "logout"
     mail_to: "Recipient"


### PR DESCRIPTION
Without some CSS hacks, the spinner will appear in the top left of the
dialog due to the div being hidden when it's rendered, and therefore
sized at 0x0 pixels.

This change ensures it appears centered and adds some qualifying text to
let the user know what is being loaded. Currently only in German and
English; other language translations will need to be sourced still
